### PR TITLE
Add `React$Element` faux-generic

### DIFF
--- a/src/convertTypeToPropTypes.js
+++ b/src/convertTypeToPropTypes.js
@@ -87,6 +87,7 @@ converters.NullLiteralTypeAnnotation = convertLiteral;
 converters.VoidTypeAnnotation = convertLiteral;
 converters.FunctionTypeAnnotation = createConversion('func');
 converters.TupleTypeAnnotation = createConversion('array');
+converters.ReactElement = createConversion('element');
 
 converters.NullableTypeAnnotation = (path: Path, opts: Options) => {
   return t.callExpression(refPropTypes(t.identifier('oneOf'), opts), [
@@ -181,6 +182,10 @@ let typeParametersConverters = {
     return t.callExpression(refPropTypes(t.identifier('arrayOf'), opts), [
       convert(param, opts),
     ]);
+  },
+  React$Element: (path: Path, opts: Options) => {
+    // ignore the parameters - the prop-types element won't accept them
+    return converters.ReactElement;
   },
 };
 


### PR DESCRIPTION
Using `React$Element<*>` provides additional safety, and it'd be nice if
this plugin would support it rather than having to `any`-stub for
`children` and go backwards.

The only thing that's holding me up is adding the test - I seem to be getting an undefined result.  Not sure if that's because the fbjs lib with the `React$Element` definition isn't included?

```
 FAIL  src/__tests__/classes.test.js
  ● react-flow-props-to-prop-types › 24. React$Element

    TypeError: unknown: Property object of MemberExpression expected node to be of a type ["Expression"] but instead got undefined
```

The test should probably look something like...

```js
    {
      title: 'React$Element',
      code: `
        class Foo extends React.Component {
          props: {
            a: React$Element<*>
          };
        }
      `,
      output: `
        import _PropTypes from "prop-types";
        class Foo extends React.Component {
          props: {
            a: React$Element<*>
          };
          static propTypes = {
            a: _PropTypes.element.isRequired
          };
        }
      `,
    },
```

Thanks for your work on this.